### PR TITLE
Update affix thresholds

### DIFF
--- a/Exlist/Modules/MythicKey.lua
+++ b/Exlist/Modules/MythicKey.lua
@@ -20,7 +20,7 @@ local colors = Exlist.Colors
 local L = Exlist.L
 
 local unknownIcon = "Interface\\ICONS\\INV_Misc_QuestionMark"
-local affixThreshold = {2, 4, 7, 10}
+local affixThreshold = {2, 7, 14}
 
 local function getTimewornKey()
    for bag = 0, 4 do
@@ -242,11 +242,6 @@ local function init()
    Exlist.ConfigDB.settings.extraInfoToggles.affixes =
       Exlist.ConfigDB.settings.extraInfoToggles.affixes or {name = L["Mythic+ Weekly Affixes"], enabled = true}
 
-   if GetExpansionLevel() == 6 then
-      affixThreshold = {4, 7, 10} -- Legion
-   else
-      affixThreshold = {2, 4, 7, 10}
-   end
    local gt = Exlist.GetCharacterTableKey("global", "global", key)
    local foundAffixes = {}
    for i = 1, #gt do


### PR DESCRIPTION
The affix thresholds are 2, 7, and 14 nowadays
I left the rest as-is, in case blizzard decides they want to add a 4th affix again, it'll be trivial to support that again :)